### PR TITLE
CSN: Only use one database in Docker (settings_dev)

### DIFF
--- a/tfc_web/csn/vertex_pg_migrations/0001_create_database.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0001_create_database.sql
@@ -1,0 +1,12 @@
+-- Create the initial database "tfcserver" for use by the java real-time platform
+--
+-- This assumes:
+--   - postgresql/postgis is already installed
+--   - user is accessing psql as user 'postgres'
+--  
+--
+-- -------------------Create database -----------------------------------
+CREATE DATABASE tfcserver;
+GRANT ALL PRIVILEGES ON DATABASE tfcserver TO tfc_prod;
+--
+

--- a/tfc_web/csn/vertex_pg_migrations/0001_reverse.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0001_reverse.sql
@@ -1,0 +1,6 @@
+-- This is the REVERSE sql for change 0001
+--
+-- The net effect of this migration is to DROP the database tfcserver.
+--
+DROP DATABASE "tfcserver";
+--

--- a/tfc_web/csn/vertex_pg_migrations/0002_create_sensor_tables.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0002_create_sensor_tables.sql
@@ -1,0 +1,44 @@
+-- Create the initial tfcserver tables (csn_sensor, csn_destination)
+--
+-- Connect to database tfcserver
+\connect tfcserver
+--
+-- -------------------Add PostGIS extension -----------------------------
+CREATE EXTENSION postgis;
+--
+-- -------------------Change user to tfc_prod
+--
+SET ROLE tfc_prod;
+--
+-- -------------------Create tables -------------------------------------
+--
+-- Create table csn_sensors
+--
+BEGIN;
+CREATE TABLE "csn_sensor" 
+(   "id" serial NOT NULL PRIMARY KEY, 
+    "info" jsonb NOT NULL
+);
+--
+CREATE        INDEX "idx_csn_sensor_info_sensor_type"             ON "csn_sensor" USING BTREE ((info->>'sensor_type'));
+CREATE UNIQUE INDEX "idx_csn_sensor_info_sensor_id_and_type"      ON "csn_sensor" ((info->>'sensor_id'),(info->>'sensor_type'));
+CREATE        INDEX "idx_csn_sensor_info_destination_id"          ON "csn_sensor" USING BTREE ((info->>'destination_id'));
+CREATE        INDEX "idx_csn_sensor_info_destination_type"        ON "csn_sensor" USING BTREE ((info->>'destination_type'));
+CREATE        INDEX "idx_csn_sensor_info_user_id"                 ON "csn_sensor" USING BTREE ((info->>'user_id'));
+--
+COMMIT;
+--
+-- Create table csn_destination
+--
+BEGIN;
+CREATE TABLE "csn_destination" 
+(   "id" serial NOT NULL PRIMARY KEY, 
+    "info" jsonb NOT NULL
+);
+--
+CREATE        INDEX "idx_csn_destination_info_destination_type"        ON "csn_destination" USING BTREE ((info->>'destination_type'));
+CREATE UNIQUE INDEX "idx_csn_destination_info_destination_id_and_type" ON "csn_destination" ((info->>'destination_id'),(info->>'destination_type'));
+CREATE        INDEX "idx_csn_destination_info_user_id"                 ON "csn_destination" USING BTREE ((info->>'user_id'));
+--
+COMMIT;
+

--- a/tfc_web/csn/vertex_pg_migrations/0002_reverse.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0002_reverse.sql
@@ -1,0 +1,9 @@
+--
+-- Reverse out the 0002_create_sensor_tables create tables / indexes
+--
+\connect tfcserver
+--
+DROP TABLE csn_sensor;
+--
+DROP TABLE csn_destination;
+--

--- a/tfc_web/csn/vertex_pg_migrations/0003_create_table_csn_sensordata.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0003_create_table_csn_sensordata.sql
@@ -1,0 +1,22 @@
+--
+-- Create table csn_sensordata in database tfcserver
+--
+\connect tfcserver
+--
+SET ROLE tfc_prod;
+
+BEGIN;
+CREATE TABLE "csn_sensordata" 
+(   "id" serial NOT NULL PRIMARY KEY, 
+    "ts" timestamp with time zone NOT NULL, 
+    "location_4d" geography(POINTZM,4326) NOT NULL, 
+    "info" jsonb NOT NULL
+);
+--
+CREATE INDEX "idx_csn_sensordata_info_sensor_id" ON "csn_sensordata" USING BTREE ((info->>'sensor_id'));
+CREATE INDEX "idx_csn_sensordata_info_sensor_type" ON "csn_sensordata" USING BTREE ((info->>'sensor_type'));
+CREATE INDEX "idx_csn_sensordata_timestamp" ON "csn_sensordata" USING BTREE ("ts" );
+CREATE INDEX "idx_csn_sensordata_location_4d" ON "csn_sensordata" USING GIST ("location_4d" );
+--
+COMMIT;
+--

--- a/tfc_web/csn/vertex_pg_migrations/0003_reverse.sql
+++ b/tfc_web/csn/vertex_pg_migrations/0003_reverse.sql
@@ -1,0 +1,7 @@
+--
+-- Reverse migration 0003_create_table_csn_sensordata
+--
+\connect tfcserver
+--
+DROP TABLE csn_sensordata;
+--

--- a/tfc_web/csn/vertex_pg_migrations/README.md
+++ b/tfc_web/csn/vertex_pg_migrations/README.md
@@ -1,0 +1,5 @@
+## Database (PostgreSQL) migrations for the tfc_server project
+
+These migrations are SQL scripts that create the initial "tfcserver" database and make release
+changes as the platform develops.
+

--- a/tfc_web/tfc_web/settings_dev.py
+++ b/tfc_web/tfc_web/settings_dev.py
@@ -1,9 +1,12 @@
 from tfc_web.settings import *
 
+# Remove the second database and its configuration
+DATABASES.pop('tfcserver')
+DATABASE_ROUTERS = []
+
 # Allow configuration of test-suite database from environment variables. A
 # variable DJANGO_DB_<key> will override the DATABASES['default'][<key>]
 # setting.
-
 _db_envvar_prefix = 'DJANGO_DB_'
 for name, value in os.environ.items():
     # Only look at variables which start with the prefix we expect
@@ -17,7 +20,6 @@ for name, value in os.environ.items():
     DATABASES['default'][name] = value
 
 # Set the API data path to point to the internal test data
-
 DATA_PATH = '/usr/src/app/api/tests/data'
 
 NEW_API_ENDPOINT = 'http://127.0.0.1:8000'


### PR DESCRIPTION
There are two databases in production (default and tfcserver). Use only one with docker. Use the PR to also add the migrations necessary for the second database for the csn app from https://github.com/ijl20/vertx_pg for info.