### PR TITLE
Change the Stops API query pagination

### DIFF
--- a/tfc_web/api/api_docs.py
+++ b/tfc_web/api/api_docs.py
@@ -131,3 +131,28 @@ transport_pagination_fields = [
         example="10",
         )
     ]
+
+transport_stops_pagination_fields = [
+    coreapi.Field(
+        "page",
+        required=False,
+        location="query",
+        schema=coreschema.Integer(
+            description="A page number within the paginated result set "
+                        "(e.g. 2). Default 1"),
+        description="A page number within the paginated result set. "
+                    "(e.g. 2)",
+        example="2",
+    ),
+    coreapi.Field(
+        "page_size",
+        required=False,
+        location="query",
+        schema=coreschema.Integer(
+            description="Number of results to return per page. "
+                        "(e.g. 10). Default 50, maximum 200."),
+        description="Number of results to return per page. "
+                    "(e.g. 10). Default 50, maximum 200.",
+        example="10",
+        )
+    ]

--- a/tfc_web/smartpanel/static/smartpanel/bus_stop_chooser/bus_stop_chooser.js
+++ b/tfc_web/smartpanel/static/smartpanel/bus_stop_chooser/bus_stop_chooser.js
@@ -285,7 +285,7 @@ var BusStopChooser = (function() {
                     // Build an initial URL (for the first page)
                     var bounds = map.getBounds().pad(0.7).toBBoxString();
                     var qs = '?bounding_box=' + encodeURIComponent(bounds);
-                    qs += '&page_size='+encodeURIComponent(50);
+                    qs += '&page_size='+encodeURIComponent(200);
                     uri = api_endpoint + 'transport/stops/' + qs;
                 }
                 if (!new_stops) {

--- a/tfc_web/transport/api/views.py
+++ b/tfc_web/transport/api/views.py
@@ -25,7 +25,7 @@ from urllib.parse import quote
 import re
 from api.auth import default_authentication, default_permission, \
     default_throttle, AuthenticateddAPIView
-from api.api_docs import transport_pagination_fields
+from api.api_docs import transport_pagination_fields, transport_stops_pagination_fields
 
 
 DAYS = [ ['Monday', 'MondayToFriday', 'MondayToSaturday', 'MondayToSunday'],
@@ -443,7 +443,7 @@ class VehicleJourneyRetrieve(generics.RetrieveAPIView):
 
 
 StopList_schema = AutoSchema(
-    manual_fields=transport_pagination_fields + [
+    manual_fields=transport_stops_pagination_fields + [
         coreapi.Field(
             "bounding_box",
             required=False,

--- a/tfc_web/transport/api/views.py
+++ b/tfc_web/transport/api/views.py
@@ -42,6 +42,12 @@ class Pagination(PageNumberPagination):
     page_size_query_param = 'page_size'
 
 
+class LongPagination(PageNumberPagination):
+    page_size = 50
+    max_page_size = 200
+    page_size_query_param = 'page_size'
+
+
 def string_to_datetime(str_time):
     try:
         time = parse(str_time)
@@ -489,7 +495,7 @@ class StopList(generics.ListAPIView):
     Return a list of bus stops.
     """
     serializer_class = StopSerializer
-    pagination_class = Pagination
+    pagination_class = LongPagination
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     ordering_fields = ('atco_code', 'common_name', 'locality_name')
     ordering = ('atco_code', )


### PR DESCRIPTION
Due to the speed improvements achieved using the new PostGIS query in the Stops list API query, increase the maximum page size to 200 and increase the limit in the bus stop chooser.