### PR TITLE
Add logging to Prometheus of run/redeploy events

### DIFF
--- a/redeploy.sh
+++ b/redeploy.sh
@@ -31,3 +31,11 @@ pip3 install -r requirements.txt
 touch tfc_web/settings*.py
 
 echo "Deployed commit $(git rev-parse --short HEAD) on branch $(git rev-parse --abbrev-ref HEAD)" >&2
+
+# Tell prometheus
+prom_dir=/var/lib/node_exporter/textfile_collector
+if [ -d "${prom_dir}" ]; then
+    prom_file="${prom_dir}/tfc_web_redeploy.prom"
+    echo "tfc_event{event=\"tfc_web_redeploy\"} $(date +%s)" > ${prom_file}.$$
+    mv ${prom_file}.$$ ${prom_file}
+fi

--- a/run.sh
+++ b/run.sh
@@ -11,3 +11,11 @@ cd /home/tfc_prod/tfc_web/tfc_web
 echo $(date) "gunicorn started " >> /var/log/tfc_prod/gunicorn.log
 
 nohup gunicorn --config /home/tfc_prod/tfc_web/gunicorn_config.py tfc_web.wsgi & disown
+
+# Tell prometheus
+prom_dir=/var/lib/node_exporter/textfile_collector
+if [ -d "${prom_dir}" ]; then
+    prom_file="${prom_dir}/tfc_web_redeploy.prom"
+    echo "tfc_event{event=\"tfc_web_run\"} $(date +%s)" > ${prom_file}.$$
+    mv ${prom_file}.$$ ${prom_file}
+fi


### PR DESCRIPTION
Add logging via node_exporter's textfile_exporter of every execution of
run.sh and redeploy.sh, providing textfile_exporter has been configured.

This is useful for driving Grafana's 'annotation' feature to show when
external events happened and for relating them to changes in metrics.