### PR TITLE
Explicitly set height/width of iframe

### DIFF
--- a/tfc_web/smartpanel/static/smartpanel/widgets/iframe_area/iframe_area.css
+++ b/tfc_web/smartpanel/static/smartpanel/widgets/iframe_area/iframe_area.css
@@ -1,6 +1,13 @@
 /* Styles for the iframe_area widget */
 
+
 .iframe_area {
+    border: none;
+    height: 100%;
+    width: 100%;
+}
+
+.iframe_area iframe {
     border: none;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
It appears that a iframe defaults to 300pxx150px if not otherwise
set. This causes problems when including some content using the
iframe_area widget.

This edit forces it to 100%x100%