### PR TITLE
Rework station_board view to better cope with errors

### DIFF
--- a/tfc_web/smartpanel/views/widgets/station_board.py
+++ b/tfc_web/smartpanel/views/widgets/station_board.py
@@ -7,6 +7,7 @@ import zeep.transports
 import zeep.cache
 import re
 import os
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -29,51 +30,66 @@ def station_board(request, ver=''):
     assert station, 'No station code found'
     offset = int(request.GET.get('offset', 0))
 
-    cache_key = "station_board!{0}!{1}".format(station, offset)
-    data = cache.get(cache_key)
+    current_key = "station_board_current!{0}!{1}".format(station, offset)
+    lng_key = "station_board_lng!{0}!{1}".format(station, offset)
+
+    data = cache.get(current_key)
     if data:
-        logger.info('Cache hit for %s', cache_key)
+        logger.info('Cache hit for %s', current_key)
 
     else:
-        logger.info('Cache miss for %s', cache_key)
+        logger.info('Cache miss for %s', current_key)
         data = {'messages': [], 'services': []}
 
         try:
+
             client = zeep.Client(wsdl=WSDL)
             raw_data = client.service.GetDepartureBoard(
                 numRows=50, crs=station,
                 _soapheaders={"AccessToken": settings.NRE_API_KEY},
                 timeOffset=offset
             )
-        except zeep.exceptions.XMLSyntaxError as e:
-            logger.error("Error retrieving station board for '{0}'".format(station))
-            logger.error("XMLSyntaxError: {0}".format(e))
-            logger.error("content={0}".format(e.content))
-            assert False, "Failed to retrieve station board"
 
-        data['locationName'] = raw_data['locationName']
-        data['generatedAt'] = raw_data['generatedAt'].strftime("%H:%M")
+            data['locationName'] = raw_data['locationName']
+            data['generatedAt'] = raw_data['generatedAt'].strftime("%H:%M")
 
-        if raw_data['nrccMessages']:
-            for message in raw_data['nrccMessages']['message']:
-                for key in message:
-                    data['messages'].append(re.sub('<[^<]+?>', '', message[key]))
-        if len(data['messages']) > 1:
-            data['messages'] = ['Multiple travel alerts in force - see www.nationalrail.co.uk for details.']
+            if raw_data['nrccMessages']:
+                for message in raw_data['nrccMessages']['message']:
+                    for key in message:
+                        data['messages'].append(re.sub('<[^<]+?>', '', message[key]))
+            if len(data['messages']) > 1:
+                data['messages'] = ['Multiple travel alerts in force - see www.nationalrail.co.uk for details.']
 
-        if raw_data['trainServices']:
-            for service in raw_data['trainServices']['service']:
-                this_service = {}
-                this_service['std'] = service['std']
-                this_service['etd'] = service['etd']
-                this_service['platform'] = service['platform'] or ''
-                dest = service['destination']['location'][0]['locationName']
-                if dest in STATION_ABBREV:
-                    dest = STATION_ABBREV[dest]
-                this_service['destination'] = dest
-                data['services'].append(this_service)
+            if raw_data['trainServices']:
+                for service in raw_data['trainServices']['service']:
+                    this_service = {}
+                    this_service['std'] = service['std']
+                    this_service['etd'] = service['etd']
+                    this_service['platform'] = service['platform'] or ''
+                    dest = service['destination']['location'][0]['locationName']
+                    if dest in STATION_ABBREV:
+                        dest = STATION_ABBREV[dest]
+                    this_service['destination'] = dest
+                    data['services'].append(this_service)
 
-        cache.set(cache_key, data, timeout=30)
+            cache.set(lng_key, data, timeout=30*60)
+
+        except:
+            logger.error(
+                "Error retrieving station board for %s: %s %s",
+                station,
+                sys.exc_info()[0],
+                sys.exc_info()[1])
+            data = cache.get(lng_key)
+            if data:
+                logger.info('Cache hit for %s', lng_key)
+            else:
+                logger.info('Cache miss for %s', lng_key)
+                data = {'messages': [], 'services': []}
+
+        # Whatever happens, cache what we got so we don't keep hitting the API
+        finally:
+            cache.set(current_key, data, timeout=30)
 
     template = 'smartpanel/station_board{0}.html'.format(ver)
     return render(request, template, {'data': data})

--- a/tfc_web/smartpanel/views/widgets/station_board.py
+++ b/tfc_web/smartpanel/views/widgets/station_board.py
@@ -2,6 +2,7 @@ import logging
 from django.core.cache import cache
 from django.shortcuts import render
 from django.conf import settings
+from django.http.response import HttpResponseBadRequest
 import zeep
 import zeep.transports
 import zeep.cache
@@ -27,7 +28,8 @@ def station_board(request, ver=''):
     and render it as a web page
     '''
     station = request.GET.get('station', '')
-    assert station, 'No station code found'
+    if station == '':
+        return HttpResponseBadRequest('Missing station identifier')
     offset = int(request.GET.get('offset', 0))
 
     current_key = "station_board_current!{0}!{1}".format(station, offset)

--- a/tfc_web/smartpanel/views/widgets/weather.py
+++ b/tfc_web/smartpanel/views/widgets/weather.py
@@ -9,6 +9,7 @@ import sys
 from django.conf import settings
 from django.core.cache import cache
 from django.shortcuts import render
+from django.http.response import HttpResponseBadRequest
 
 
 logger = logging.getLogger(__name__)
@@ -266,7 +267,8 @@ def weather(request, ver=''):
     and render it for inclusion in a widgit
     '''
     location = request.GET.get('location', '')
-    assert location, 'No location code found'
+    if location == '':
+        return HttpResponseBadRequest('Missing location code')
 
     forecasts = get_forecast_list(forecast_breakpoints)
 


### PR DESCRIPTION
As with weather, arrange to cache the last known good station board
for a particular station and use that data if an attempt to retrieve
new information fails. As well as allowing station board widgets to
ride over outages of the underlying service, this will prevent
exceptions being thrown when this happens and so avoid torrents
of emails from the logging system.

Unlike weather, only cache last known good data for half an hour
since it will be stale after that.

Closes #302 