### PR TITLE
Avoid error when we have multiple entries with the same slug

### DIFF
--- a/tfc_web/transport/views.py
+++ b/tfc_web/transport/views.py
@@ -76,6 +76,38 @@ class ServiceDetailView(DetailView):
 
     model = Line
     template_name = "transport/new_timetable.html"
+    
+    def get_object(self, queryset=None):
+        """
+        Returns the object the view is displaying.
+        By default this requires `self.queryset` and a `pk` or `slug` argument
+        in the URLconf, but subclasses can override this to return any object.
+        """
+        # Use a custom queryset if provided; this is required for subclasses
+        # like DateDetailView
+        if queryset is None:
+            queryset = self.get_queryset()
+        # Next, try looking up by primary key.
+        pk = self.kwargs.get(self.pk_url_kwarg)
+        slug = self.kwargs.get(self.slug_url_kwarg)
+        if pk is not None:
+            queryset = queryset.filter(pk=pk)
+        # Next, try looking up by slug.
+        if slug is not None and (pk is None or self.query_pk_and_slug):
+            slug_field = self.get_slug_field()
+            queryset = queryset.filter(**{slug_field: slug})
+        # If none of those are defined, it's an error.
+        if pk is None and slug is None:
+            raise AttributeError("Generic detail view %s must be called with "
+                                 "either an object pk or a slug."
+                                 % self.__class__.__name__)
+        try:
+            # Get the single item from the filtered queryset
+            obj = queryset.first()
+            if obj is None:
+                raise Http404(_("No %(verbose_name)s found matching the query") % 
+                              {'verbose_name': queryset.model._meta.verbose_name})
+        return obj
 
     def get_context_data(self, **kwargs):
         context = super(ServiceDetailView, self).get_context_data(**kwargs)


### PR DESCRIPTION
This doesn't solve the problem but it avoids throwing an error. We need to make slug to be unique in the data model to avoid this occurring as the we won't be able to access to all those entries that have the same slug. This is an edge case, though.

Closes #301 