### PR TITLE
Restrict emailing errors to production machines

### DIFF
--- a/tfc_web/tfc_web/settings.py
+++ b/tfc_web/tfc_web/settings.py
@@ -286,15 +286,12 @@ LOGGING = {
         }
     },
     'loggers': {
-        #'django': {
-        #    'handlers': ['console'],
-        #    #'level': 'INFO',
+        # Moved to settings_production
+        #'django.request': {
+        #    'handlers': ['mail_admins'],
+        #    'level': 'ERROR',
+        #    'propagate': False,
         #},
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
     },
     'root': {
         'handlers': ['console'],

--- a/tfc_web/tfc_web/settings_production.py
+++ b/tfc_web/tfc_web/settings_production.py
@@ -7,3 +7,9 @@ EMAIL_HOST = "ppsw.cam.ac.uk"
 EMAIL_PORT = 25
 
 CSN_PREFIX = 'prod'
+
+LOGGING['loggers']['django.request'] = {
+    'handlers': ['mail_admins'],
+    'level': 'ERROR',
+    'propagate': False,
+    }


### PR DESCRIPTION
Move the definition of the logger that causes emails to be sent
on errors from settings.py (which is used by everything) to
settings_production.py (which is used in production).

The intension is to stop emails being generated on development
machines (which are probably running with DEBUG=True and so will
show tracebacks anyway).