### PR TITLE
Fix capacity annotation on car park graphs

### DIFF
--- a/tfc_web/parking/api/serializers.py
+++ b/tfc_web/parking/api/serializers.py
@@ -32,7 +32,6 @@ class ParkingConfigSerializer(serializers.Serializer):
     parking_id = serializers.CharField()
     parking_name = serializers.CharField()
     parking_type = serializers.CharField()
-    spaces_capacity = serializers.IntegerField(source='capacity')
 
 
 class ParkingListSerializer(serializers.Serializer):

--- a/tfc_web/parking/templates/parking/parking_plot.html
+++ b/tfc_web/parking/templates/parking/parking_plot.html
@@ -123,6 +123,24 @@ var DD = {{config_DD}};     // day e.g. 23
 
 var parking_config = JSON.parse('{{ config_parking_config|escapejs }}');
 
+try {
+    // **********************************************************************************
+    // **********  Here is where we load the parking plot data    ***********************
+    // **********************************************************************************
+    var json_data = JSON.parse("{{ config_parking_data|escapejs }}");
+    // **********************************************************************************
+    // **********************************************************************************
+    // **********************************************************************************
+    if (!json_data)
+    {
+        console.log('no parking data received');
+    }
+} catch(err) {
+    console.log('error parsing config_parking_data '+err);
+    rita_data = new Array();
+}
+
+
 var YYYYMMDD = '{{config_YYYY}}/{{config_MM}}/{{config_DD}}';
 //********************************************************************************
 //********************************************************************************
@@ -211,13 +229,15 @@ function init()
 
     heading_date.textContent = day_of_week[plot_date.getDay()] + " " + DD + " " + month_of_year[MM] + " " + YYYY;
 
-    // get max occupancy for this car park from parking_config and adjust CHART_Y_MAX
-    try {
-          parking_capacity = parking_config.request_data.capacity;
-          console.log('Capacity of this car park is: '+parking_capacity);
-          CHART_Y_MAX = (1.2 * parking_capacity);
-          document.getElementById('parking_capacity').innerHTML = "(max "+parking_capacity+")";
-    } catch (err) {
+    // get max occupancy for this car park from the final occupancy record
+    // for the day the graph is being drawn
+
+    if (json_data && json_data[0].request_data.length > 0) {
+      final_record = json_data[0].request_data[json_data[0].request_data.length-1]
+      parking_capacity = final_record.spaces_capacity
+      console.log('Capacity of this car park is: '+parking_capacity);
+      CHART_Y_MAX = (1.2 * parking_capacity);
+      document.getElementById('parking_capacity').innerHTML = "(max "+parking_capacity+")";
     }
 
     // ******************************************************
@@ -231,41 +251,28 @@ function init()
 
     // Initialize data structure to hold parking occupancy messages inserted by server
     // And call draw_chart for each day's data
-    try {
-        // **********************************************************************************
-        // **********  Here is where we load the parking plot data    ***********************
-        // **********************************************************************************
-        var json_data = JSON.parse("{{ config_parking_data|escapejs }}");
-        // **********************************************************************************
-        // **********************************************************************************
-        // **********************************************************************************
-        if (!json_data)
-        {
-            console.log('no parking data received');
-        }
-        else
-        {
-            console.log('Rendering '+json_data.length+' days of data');
 
-            // note we draw requested day's data last so it is on top...
-            for (i=json_data.length-1;i>=0;i--)
+
+
+    if (json_data) 
+    {
+        console.log('Rendering '+json_data.length+' days of data');
+
+        // note we draw requested day's data last so it is on top...
+        for (i=json_data.length-1;i>=0;i--)
+        {
+            rita_data = json_data[i].request_data;
+            console.log('Day '+i+': Received '+rita_data.length+' records');
+
+            if (rita_data.length > 0)
             {
-                rita_data = json_data[i].request_data;
-                console.log('Day '+i+': Received '+rita_data.length+' records');
+              console.log('Day '+i+': init calling draw_chart()');
 
-                if (rita_data.length > 0)
-                {
-                  console.log('Day '+i+': init calling draw_chart()');
-
-                  // draw chart with the data embedded by the template into rita_data
-                  draw_chart(rita_data, i);
-                }
-                console.log('Day '+i+': rita_data.length is '+rita_data.length);
+              // draw chart with the data embedded by the template into rita_data
+              draw_chart(rita_data, i);
             }
+            console.log('Day '+i+': rita_data.length is '+rita_data.length);
         }
-    } catch(err) {
-        console.log('error parsing config_parking_data '+err);
-        rita_data = new Array();
     }
 
 }

--- a/tfc_web/parking/views.py
+++ b/tfc_web/parking/views.py
@@ -24,7 +24,6 @@ def get_parking_metadata(parking_id):
 
     data = do_api_call('/api/v1/parking/' + parking_id)
     # Fix for change between old and new API field names
-    data['capacity'] = data['spaces_capacity']
     return {'request_data': data}
 
 


### PR DESCRIPTION
The capacity marker (red line and '(max xxxx)' wording) for the car parks comes from the static car park metadata which can't cope with changes to capacity over time.

By comparison, the list and the map pages get this information from the 'capacity' field of the occupancy record.

This edit changes the graph logic to use the capacity from the last occupancy record for the day being plotted. This still isn't quite right for a day on which the capacity changes or given decreasing capacity and prior_days plots, but since these are rare events it's not worth worrying about.

At the same time, drop `spaces_capacity` from car park metadata returned by the API - a single capacity entry can't reflect changes to capacity over time and while these are rare they do happen. So having this field is misleading and a maintenance problem.

Closes #319