### PR TITLE
Jw35 smartpanel admin 2

### DIFF
--- a/tfc_web/smartpanel/admin.py
+++ b/tfc_web/smartpanel/admin.py
@@ -2,9 +2,10 @@ from django.contrib.admin import ModelAdmin
 from smartpanel.models import Layout, Display, Pocket
 from django.utils.safestring import mark_safe
 from django.urls import reverse
+from django.contrib.gis import admin as admin
 
 
-class DisplayAdmin(admin.ModelAdmin):
+class DisplayAdmin(admin.OSMGeoAdmin):
     list_display = ('slug', 'name', 'layout_link', 'owner_link')
     search_fields = ('slug', 'name', 'owner__username')
 
@@ -23,7 +24,7 @@ class DisplayAdmin(admin.ModelAdmin):
     layout_link.short_description = 'Layout'
     layout_link.admin_order_field = 'layout__name'
 
-class LayoutAdmin(admin.ModelAdmin):
+class LayoutAdmin(admin.OSMGeoAdmin):
     list_display = ('slug', 'name', 'owner_link')
     search_fields = ('slug', 'name', 'owner__username')
 

--- a/tfc_web/smartpanel/admin.py
+++ b/tfc_web/smartpanel/admin.py
@@ -1,8 +1,40 @@
-from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from smartpanel.models import Layout, Display, Pocket
+from django.utils.safestring import mark_safe
+from django.urls import reverse
 
-admin.site.register(Layout, ModelAdmin)
-admin.site.register(Display, ModelAdmin)
+
+class DisplayAdmin(admin.ModelAdmin):
+    list_display = ('slug', 'name', 'layout_link', 'owner_link')
+    search_fields = ('slug', 'name', 'owner__username')
+
+    def owner_link(self, display):
+        url = reverse("admin:auth_user_change", args=[display.owner.id])
+        link = '<a href="%s">%s</a>' % (url, display.owner.username)
+        return mark_safe(link)
+    owner_link.short_description = 'Owner'
+    owner_link.admin_order_field = 'owner__username'
+
+
+    def layout_link(self, display):
+        url = reverse("admin:smartpanel_layout_change", args=[display.layout.id])
+        link = '<a href="%s">%s</a>' % (url, display.layout)
+        return mark_safe(link)
+    layout_link.short_description = 'Layout'
+    layout_link.admin_order_field = 'layout__name'
+
+class LayoutAdmin(admin.ModelAdmin):
+    list_display = ('slug', 'name', 'owner_link')
+    search_fields = ('slug', 'name', 'owner__username')
+
+    def owner_link(self, display):
+        url = reverse("admin:auth_user_change", args=[display.owner.id])
+        link = '<a href="%s">%s</a>' % (url, display.owner.username)
+        return mark_safe(link)
+    owner_link.short_description = 'Owner'
+    owner_link.admin_order_field = 'owner__username'
+
+
+admin.site.register(Layout, LayoutAdmin)
+admin.site.register(Display, DisplayAdmin)
 admin.site.register(Pocket, ModelAdmin)
-

--- a/tfc_web/smartpanel/models.py
+++ b/tfc_web/smartpanel/models.py
@@ -56,7 +56,7 @@ class Display(models.Model):
 
     @python_2_unicode_compatible
     def __str__(self):
-        return self.name
+        return "%s (%s)" % (self.name, self.slug)
 
 class Pocket(models.Model):
     name = models.CharField(max_length=100, unique=True)


### PR DESCRIPTION
1) Improve Django admin for Smartpanels

    Add useful fields and searching to the Django admin list display for
    Smartpanel displays and layouts, in particular to make it easier
    to find the owner of a particular panel.

    Also add 'slug' to the result of `__str__` for displays since typically
    the name is useless.

2) Use OSM for editing Smartpanel locations in Django admin

    Without this edit, django.contrib.gis.db.models.PointField fields
    are displayed on a low-res aerial view.
