### PR TITLE
Add new makemigrations target to docker-compose

### DIFF
--- a/tfc_web/docker-compose.yml
+++ b/tfc_web/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     <<: *devserver
     entrypoint: ["wait-for-it", "db:5432", "-t", "5", "--"]
     command: ["./manage.py", "migrate"]
+  makemigrations:
+    <<: *devserver
+    entrypoint: ["wait-for-it", "db:5432", "-t", "5", "--"]
+    command: ["./manage.py", "makemigrations"]
   shell:
     <<: *devserver
     command: ["shell"]


### PR DESCRIPTION
Add a new 'target' (or whatever they are called) to the docker-compose
script that will run './manage.py makemigrations' as a convenience
when changing database schemas.

This requires that the /usr/src/app volume is mounter read-write,
but fortunately it already is...