### PR TITLE
Require moderator approval for postings

### DIFF
--- a/tfc_web/tfc_web/settings.py
+++ b/tfc_web/tfc_web/settings.py
@@ -187,7 +187,6 @@ MACHINA_DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS = [
     'can_start_new_topics',
     'can_reply_to_topics',
     'can_edit_own_posts',
-    'can_post_without_approval',
     'can_create_polls',
     'can_vote_in_polls',
     'can_download_file',


### PR DESCRIPTION
This edit addresses a steady trickle of advertising spam on the forum
by requiring moderator approval for new posts. It works by removing
'can_post_without_approval' from the
MACHINA_DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS configuration
list.

Note that Machina doesn't alert administrators to the presence
of items awaiting moderation so someone needs to check the moderation
queue from time to time using the link on the forum front page.