### PR TITLE
Fix the menu on the Pocket SmartPanel usage graphs

### DIFF
--- a/tfc_web/smartpanel/templates/smartpanel/pocketlog_total.html
+++ b/tfc_web/smartpanel/templates/smartpanel/pocketlog_total.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "smartpanel/base.html" %}
 {% load static %}
 {% block page_title %}Pocket SmartPanel{% endblock %}
 {% block mobile_title %}Pocket SmartPanel{% endblock %}

--- a/tfc_web/smartpanel/templates/smartpanel/pocketlog_unique.html
+++ b/tfc_web/smartpanel/templates/smartpanel/pocketlog_unique.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "smartpanel/base.html" %}
 {% load static %}
 {% block page_title %}Pocket SmartPanel{% endblock %}
 {% block mobile_title %}Pocket SmartPanel{% endblock %}


### PR DESCRIPTION
The graph pages were inheriting from base.html, rather then
smartpanel/base.html and so had the main site left-hand menu rather then
the one used on other SmartPanel pages. This was particularly silly because
the SmartPanel menu is the only place that links to the graphs appear.
This edit fixes this.