### PR TITLE
Add error checking when extracting API data

### DIFF
--- a/tfc_web/api/extractors/bus.py
+++ b/tfc_web/api/extractors/bus.py
@@ -30,10 +30,15 @@ def bus_extractor(files, writer):
     writer.writerow([f for f in fields])
 
     for file in files:
-        logger.debug('Processing %s', file)
-        with open(file) as reader:
-            data = json.load(reader)
-            for record in data['request_data']:
-                record['ts'] = record['acp_ts']
-                record['ts_text'] = epoch_to_text(record['acp_ts'])
-                writer.writerow([record.get(f) for f in fields])
+        try:
+            logger.debug('Processing %s', file)
+            with open(file) as reader:
+                data = json.load(reader)
+                for record in data['request_data']:
+                    record['ts'] = record['acp_ts']
+                    record['ts_text'] = epoch_to_text(record['acp_ts'])
+                    writer.writerow([record.get(f) for f in fields])
+        except OSError as e:
+            logger.error('Error opening %s: %s', file, e)
+        except json.decoder.JSONDecodeError as e:
+            logger.error('Error decoding %s: %s', file, e)

--- a/tfc_web/api/extractors/parking.py
+++ b/tfc_web/api/extractors/parking.py
@@ -25,12 +25,17 @@ def cam_park_rss_extractor(files, writer):
     writer.writerow(fields)
 
     for file in files:
-        logger.debug('Processing %s', file)
-        with open(file) as reader:
-            for line in reader:
-                data = json.loads(line)
-                data['ts_text'] = epoch_to_text(data['ts'])
-                writer.writerow([data.get(f) for f in fields])
+        try:
+            logger.debug('Processing %s', file)
+            with open(file) as reader:
+                for line in reader:
+                    data = json.loads(line)
+                    data['ts_text'] = epoch_to_text(data['ts'])
+                    writer.writerow([data.get(f) for f in fields])
+        except OSError as e:
+            logger.error('Error opening %s: %s', file, e)
+        except json.decoder.JSONDecodeError as e:
+            logger.error('Error decoding %s: %s', file, e)
 
 
 # Metadata extractors for each storage type. They receive a single filename
@@ -43,8 +48,13 @@ def cam_park_rss_metadata_extractor(files, writer):
     writer.writerow(fields)
 
     assert len(files) == 1, 'Expecting exactly one file'
-    logger.debug('Processing %s', files[0])
-    with open(files[0]) as reader:
-        data = json.load(reader)
-        for carpark in data['parking_list']:
-            writer.writerow([carpark.get(f) for f in fields])
+    try:
+        logger.debug('Processing %s', files[0])
+        with open(files[0]) as reader:
+            data = json.load(reader)
+            for carpark in data['parking_list']:
+                writer.writerow([carpark.get(f) for f in fields])
+    except OSError as e:
+        logger.error('Error opening %s: %s', files[0], e)
+    except json.decoder.JSONDecodeError as e:
+        logger.error('Error decoding %s: %s', files[0], e)

--- a/tfc_web/api/extractors/zone.py
+++ b/tfc_web/api/extractors/zone.py
@@ -27,15 +27,20 @@ def zone_extractor(files, writer):
     writer.writerow(fields)
 
     for file in files:
-        logger.debug('Processing %s', file)
-        with open(file) as reader:
-            for line in reader:
-                data = json.loads(line)
-                data['ts_text'] = epoch_to_text(data['ts'])
-                data['zone_id'] = data['module_id']
-                if 'distance' in data:
-                    data['distance'] = round(data['distance'])
-                writer.writerow([data.get(f) for f in fields])
+        try:
+            logger.debug('Processing %s', file)
+            with open(file) as reader:
+                for line in reader:
+                    data = json.loads(line)
+                    data['ts_text'] = epoch_to_text(data['ts'])
+                    data['zone_id'] = data['module_id']
+                    if 'distance' in data:
+                        data['distance'] = round(data['distance'])
+                    writer.writerow([data.get(f) for f in fields])
+        except OSError as e:
+            logger.error('Error opening %s: %s', file, e)
+        except json.decoder.JSONDecodeError as e:
+            logger.error('Error decoding %s: %s', file, e)
 
 # Metadata extractors for each storage type. They receive a single filename
 # in 'files' and a CSV writer object.
@@ -48,10 +53,15 @@ def zone_metadata_extractor(files, writer):
     writer.writerow(fields)
 
     assert len(files) == 1, 'Expecting exactly one file'
-    logger.debug('Processing %s', files[0])
-    with open(files[0]) as reader:
-        for zone in json.load(reader)['zone_list']:
-            data = {re.sub(r'\.', '_', key): value for (key, value) in zone.items()}
-            data['zone_center'] = '{0[lat]}|{0[lng]}'.format(data['zone_center'])
-            data['zone_path'] = '|'.join(['{0[lat]}|{0[lng]}'.format(point) for point in data['zone_path']])
-            writer.writerow([data.get(f) for f in fields])
+    try:
+        logger.debug('Processing %s', files[0])
+        with open(files[0]) as reader:
+            for zone in json.load(reader)['zone_list']:
+                data = {re.sub(r'\.', '_', key): value for (key, value) in zone.items()}
+                data['zone_center'] = '{0[lat]}|{0[lng]}'.format(data['zone_center'])
+                data['zone_path'] = '|'.join(['{0[lat]}|{0[lng]}'.format(point) for point in data['zone_path']])
+                writer.writerow([data.get(f) for f in fields])
+    except OSError as e:
+        logger.error('Error opening %s: %s', files[0], e)
+    except json.decoder.JSONDecodeError as e:
+        logger.error('Error decoding %s: %s', files[0], e)


### PR DESCRIPTION
Catch and log OSError and json.decoder.JSONDecodeError when reading files to create archives, rather than just letting the process abort.