### PR TITLE
Program api improvements

### DIFF
--- a/tfc_web/api/extractors/zone.py
+++ b/tfc_web/api/extractors/zone.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 def zone_extractor(files, writer):
 
     logger.debug('In zone_extractor')
-    fields = ('zone_id', 'ts', 'ts_text', 'duration', 'distance', 'ts_delta', 'vehicle_id')
+    fields = ('zone_id', 'ts', 'ts_text', 'duration', 'distance', 'ts_delta', 'vehicle_id',
+              'line', 'direction', 'operator', 'origin', 'destination', 'departure_time')
     writer.writerow(fields)
 
     for file in files:
@@ -35,6 +36,12 @@ def zone_extractor(files, writer):
                 data['zone_id'] = data['module_id']
                 if 'distance' in data:
                     data['distance'] = round(data['distance'])
+                data['line'] = data['position_record'].get('LineRef')
+                data['direction'] = data['position_record'].get('DirectionRef')
+                data['operator'] = data['position_record'].get('OperatorRef')
+                data['origin'] = data['position_record'].get('OriginRef')
+                data['destination'] = data['position_record'].get('DestinationRef')
+                data['departure_time'] = data['position_record'].get('OriginAimedDepartureTime')
                 writer.writerow([data.get(f) for f in fields])
 
 # Metadata extractors for each storage type. They receive a single filename

--- a/tfc_web/api/templates/api/zone-schema.html
+++ b/tfc_web/api/templates/api/zone-schema.html
@@ -70,6 +70,60 @@ section of road with these columns:</p>
                 of the bus involved.</td>
         </tr>
 
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">line</td>
+            <td class="mdl-data-table__cell--non-numeric">An identifier for the 'line'
+                (e.g. timetable route) that the bus was servicing at the time of
+                the zone completion. These have a close but not exact relationship to the line
+                identifiers in the timetable information published by
+                the <a href="http://www.travelinedata.org.uk/traveline-open-data/traveline-national-dataset/">Traveline National Dataset (TNDS)</a>.
+            </td>
+        </tr>
+
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">direction</td>
+            <td class="mdl-data-table__cell--non-numeric">The direction of travel of
+                the vehicle on its 'line'. Typically either 'INBOUND" or 'OUTBOUND'.
+            </td>
+        </tr>
+
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">operator</td>
+            <td class="mdl-data-table__cell--non-numeric">A code for the operator of
+                the vehicle.
+            </td>
+        </tr>
+
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">origin</td>
+            <td class="mdl-data-table__cell--non-numeric">First stop on the
+                timetabled journey currently assigned to the vehicle that transited the zone,
+                expressed as
+                the 'ATOCCode' of the stop in the
+                <a href="https://data.gov.uk/dataset/ff93ffc1-6656-47d8-9155-85ea0b8f2251/national-public-transport-access-nodes-naptan">National
+                Public Transport Access Nodes (NaPTAN)</a> database.
+            </td>
+        </tr>
+
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">destination</td>
+            <td class="mdl-data-table__cell--non-numeric">Last stop on the
+                timetabled journey currently assigned to the vehicle that transited the zone,
+                expressed as
+                the 'ATOCCode' of the stop in the
+                <a href="https://data.gov.uk/dataset/ff93ffc1-6656-47d8-9155-85ea0b8f2251/national-public-transport-access-nodes-naptan">National
+                Public Transport Access Nodes (NaPTAN)</a> database.
+            </td>
+        </tr>
+
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">departure_time</td>
+            <td class="mdl-data-table__cell--non-numeric">The timetabled departure time
+                from the origin stop for the timetabled journey currently assigned to the
+                vehicle that transited the zone.
+            </td>
+        </tr>
+
     </tbody>
 
 </table>

--- a/tfc_web/traffic/api/serializers.py
+++ b/tfc_web/traffic/api/serializers.py
@@ -2,6 +2,17 @@ from rest_framework import serializers
 from api import util
 
 
+class ZoneJourneySerializer(serializers.Serializer):
+    line = serializers.CharField(source='LineRef')
+    direction = serializers.CharField(source='DirectionRef')
+    operator = serializers.CharField(source='OperatorRef')
+    origin = serializers.CharField(source='OriginRef')
+    origin_name = serializers.CharField(source='OriginName')
+    destination = serializers.CharField(source='DestinationRef')
+    destination_name = serializers.CharField(source='DestinationName')
+    departure_time = serializers.CharField(source='OriginAimedDepartureTime')
+
+
 class ZoneRecordSerializer(serializers.Serializer):
     acp_ts = serializers.IntegerField(source='ts')
     date = util.EpochField(source='ts')
@@ -11,6 +22,7 @@ class ZoneRecordSerializer(serializers.Serializer):
     vehicle_id = serializers.CharField()
     distance = serializers.FloatField(required=False)
     avg_speed = serializers.FloatField(required=False)
+    journey = ZoneJourneySerializer(source='position_record')
 
 
 class ZoneHistorySerializer(serializers.Serializer):

--- a/tfc_web/traffic/templates/traffic/zone_transit_plot.html
+++ b/tfc_web/traffic/templates/traffic/zone_transit_plot.html
@@ -432,7 +432,7 @@ function draw_chart(rita_data)
           .attr('dx', CHART_DOT_RADIUS+10)
           .style('font-size', '22px')
           .style('fill', '#333')
-          .text(p.duration+p_time_str);
+          .text(p.duration+' sec.'+p_time_str);
     
 } // end draw_chart
 
@@ -440,13 +440,16 @@ function draw_chart(rita_data)
  // The point may have originated from GTFS feedhandler, GTFS feedmaker, or SIRI feedmaker
 function tooltip_html(d)
 {
-    var str = 'Zone: '+zone.zone_id;
+    var str = 'Zone:'+zone.zone_id;
     str += '<br/>Vehicle:'+d.vehicle_id;
-    str += '<br/>Transit time (secs):'+d.duration;
+    str += '<br/>Transit time:'+d.duration+' sec';
+    if (d.distance) {
+      str += '<br/>Distance:'+Math.round(d.distance)+' m';
+    }
     str += '<br/>Time:' + make_date(d.ts);
-    if (d.position_record)
+    if (d.journey)
     {
-        str += '<br/>'+JSON.stringify(d.position_record).replace(/,/g,', ');
+        str += '<br/>'+JSON.stringify(d.journey).replace(/,/g,', ');
     }
     if (d.route_id)
     {


### PR DESCRIPTION
1) Add details of the bus journey responsible for each zone completion to the response to the zone-->history API endpoint and to the zone data available in the download API. This data used to be available (at least internally) but wasn't included in the API as originally launched. This data has some utility (it supplies data about the service and timetable journey, for example, and it was
displayed in a popup on the zone transit graph)

    Closes #203

2) Add (restore) journey details to the popup on the zone transit time graphs. This
functionality was lost in the move to the REST API because the API didn't include this data.

3) Allow the result of the transport-->journey API endpoint to optionally
be filtered by line name and/or operator. Helps to reduce the number of API calls
required if you know something about the data you want.

    Closes #350

**Note**: this PR contains a (simple) conflict with changes in #351 and this will have to be resolved at some stage.