### PR TITLE
Stop graph navigation polluting browser history

### DIFF
--- a/tfc_web/aq/templates/aq/aq_plot.html
+++ b/tfc_web/aq/templates/aq/aq_plot.html
@@ -659,17 +659,17 @@ function url_replace(url, key, value)
     </div>
     <div id="chart_title">
       <div id="page_date">
-        <div class="time_shift"><a href="#" onclick="date_shift(-7)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-7); return false">
             <img src="{% static 'images/chevron-left-left.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(-1)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-1); return false">
             <img src="{% static 'images/chevron-left.png' %}"></a>
         </div>
         <div id="heading_date"></div>
-        <div class="time_shift"><a href="#" onclick="date_shift(1);">
+        <div class="time_shift"><a href="#" onclick="date_shift(1); return false">
             <img src="{% static 'images/chevron-right.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(7);">
+        <div class="time_shift"><a href="#" onclick="date_shift(7); return false">
             <img src="{% static 'images/chevron-right-right.png' %}"></a>
         </div>
       </div> <!-- end page_date -->

--- a/tfc_web/parking/templates/parking/parking_plot.html
+++ b/tfc_web/parking/templates/parking/parking_plot.html
@@ -553,17 +553,17 @@ function date_shift(n)
 <div id="content">
     <div id="chart_title">
       <div id="page_date">
-        <div class="time_shift"><a href="#" onclick="date_shift(-7)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-7); return false">
             <img src="{% static 'images/chevron-left-left.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(-1)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-1); return false">
             <img src="{% static 'images/chevron-left.png' %}"></a>
         </div>
         <div id="heading_date"></div>
-        <div class="time_shift"><a href="#" onclick="date_shift(1);">
+        <div class="time_shift"><a href="#" onclick="date_shift(1); return false">
             <img src="{% static 'images/chevron-right.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(7);">
+        <div class="time_shift"><a href="#" onclick="date_shift(7); return false">
             <img src="{% static 'images/chevron-right-right.png' %}"></a>
         </div>
       </div> <!-- end page_date -->

--- a/tfc_web/traffic/templates/traffic/zone_transit_plot.html
+++ b/tfc_web/traffic/templates/traffic/zone_transit_plot.html
@@ -513,17 +513,17 @@ function make_date(ts)
 <div id="content">
     <div id="chart_title">
       <div id="page_date">
-        <div class="time_shift"><a href="#" onclick="date_shift(-7)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-7); return false">
             <img src="{% static 'images/chevron-left-left.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(-1)">
+        <div class="time_shift"><a href="#" onclick="date_shift(-1); return false">
             <img src="{% static 'images/chevron-left.png' %}"></a>
         </div>
         <div id="heading_date"></div>
-        <div class="time_shift"><a href="#" onclick="date_shift(1);">
+        <div class="time_shift"><a href="#" onclick="date_shift(1); return false">
             <img src="{% static 'images/chevron-right.png' %}"></a>
         </div>
-        <div class="time_shift"><a href="#" onclick="date_shift(7);">
+        <div class="time_shift"><a href="#" onclick="date_shift(7); return false">
             <img src="{% static 'images/chevron-right-right.png' %}"></a>
         </div>
         {% if config_zone_reverse_id %}


### PR DESCRIPTION
The next/previous day/month navigation on the aq, parking and traffic
graphs pollutes browser history by adding two entries for each click -
one to the current URl with '#' appended, one to the wanted URL.

This edit stops this happening by arranging for the 'onclick' handler
to return 'false'.

[Yes, I know use of onclick= should be replaced by nicer DOM manipulation
but the approach in this edit is minimally invasive]

Closes #355