### PR TITLE
Work around period appearing as {} (empty object)

### DIFF
--- a/tfc_web/api/extractors/btjourney.py
+++ b/tfc_web/api/extractors/btjourney.py
@@ -4,6 +4,7 @@ The functions used by the build_download_data command to extract
 Bluetooth-derived journey data and store it in CVS files.
 '''
 
+import collections
 import json
 import logging
 
@@ -31,6 +32,13 @@ def btjourney_journey_extractor(files, writer):
                 for line in reader:
                     data = json.loads(line)
                     data['ts_text'] = epoch_to_text(data['ts'])
+                    # For reasons unknown, the period field in journey data
+                    # is occasionally an empty object rather than an integer.
+                    # In particular this has been observed for very recently
+                    # created links (see e.g. CAMBRIDGE_JTMS|9800YRAA8RIZ on
+                    # 2020-02-16)
+                    if isinstance(data['period'], collections.Mapping):
+                        data['period'] = None
                     writer.writerow([data.get(f) for f in fields])
         except OSError as e:
             logger.error('Error opening %s: %s', file, e)

--- a/tfc_web/traffic/api/views.py
+++ b/tfc_web/traffic/api/views.py
@@ -1,3 +1,4 @@
+import collections
 from datetime import timedelta
 import logging
 import os
@@ -324,6 +325,15 @@ class BTJourneyLinkHistory(auth.AuthenticateddAPIView):
                 results = results + util.read_json_fragments(filename)
             except FileNotFoundError:
                 pass
+
+        # For reasons unknown, the period field in journey data is occasionally
+        # an empty object rather than an integer. In particular this has been
+        # observed for very recently created links
+        # (see e.g. CAMBRIDGE_JTMS|9800YRAA8RIZ on 2020-02-16)
+        for result in results:
+            if isinstance(result['period'], collections.Mapping):
+                result['period'] = None
+
         serializer = BTJourneyLinkRecordListSerializer({'request_data': results})
         return Response(serializer.data)
 


### PR DESCRIPTION
For reasons unknown, the period field in journey data is occasionally
an empty object rather than an integer. In particular this has been
observed for very recently created links
(see e.g. this from CAMBRIDGE_JTMS|9800YRAA8RIZ on 2020-02-16):

```
{
  "id": "CAMBRIDGE_JTMS|9800YRAA8RIZ",
  "time": null,
  "period": {},
  "travelTime": null,
  "normalTravelTime": null,
  "ts": 1581858394
}
```

This causes the corresponding searilizer to complain. This fix overwrites
such valuse with None which searalizes as 'null' as expected.