### PR TITLE
Restore sorting of the list of downloadable files

### DIFF
--- a/tfc_web/api/views.py
+++ b/tfc_web/api/views.py
@@ -99,7 +99,7 @@ def download(request):
                 # Include all the filenames in archive directory that match the pattern
                 # and which don't accidentally include the string 'metadata'
                 filenames = [
-                    f for f in os.listdir(os.path.join(source_dir, feed['name']))
+                    f for f in sorted(os.listdir(os.path.join(source_dir, feed['name'])))
                     if re.fullmatch(archive_pattern, f) and 'metadata' not in f
                 ]
                 data.append({


### PR DESCRIPTION
The changes in 1def58b1 lost a call to sorted() around os.listdir(),
with the result that downloadable files appeared in directory order
rather than sorted by date. This edit restores the omission.